### PR TITLE
Adds ownership column to dataset table

### DIFF
--- a/components/datasets/table/DatasetsTable.js
+++ b/components/datasets/table/DatasetsTable.js
@@ -22,6 +22,7 @@ import NameTD from './td/NameTD';
 import PublishedTD from './td/PublishedTD';
 import StatusTD from './td/StatusTD';
 import RelatedContentTD from './td/RelatedContentTD';
+import OwnershipTD from './td/OwnershipTD';
 import UpdatedAtTD from './td/UpdatedAtTD';
 
 class DatasetsTable extends React.Component {
@@ -58,7 +59,7 @@ class DatasetsTable extends React.Component {
   }
 
   render() {
-    const { routes, getDatasetsFilters } = this.props;
+    const { routes, getDatasetsFilters, user } = this.props;
 
     return (
       <div className="c-dataset-table">
@@ -88,6 +89,7 @@ class DatasetsTable extends React.Component {
               { label: 'Status', value: 'status', td: StatusTD },
               { label: 'Published', value: 'published', td: PublishedTD },
               { label: 'Provider', value: 'provider' },
+              { label: 'Ownership', value: 'userId', td: OwnershipTD, tdProps: { user } },
               { label: 'Updated at', value: 'updatedAt', td: UpdatedAtTD },
               { label: 'Related content', value: 'status', td: RelatedContentTD, tdProps: { route: routes.detail } }
             ]}

--- a/components/datasets/table/td/OwnershipTD.js
+++ b/components/datasets/table/td/OwnershipTD.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function OwnershipTD(props) {
+  const { user, index, row } = props;
+  const { userId } = row;
+  const { id } = user;
+
+  return (
+    <td className="boolean" key={index}>
+      {(userId === id) ? <span className="-true">Me</span> : <span className="-false">Others</span> }
+    </td>
+  );
+}
+
+OwnershipTD.propTypes = {
+  index: PropTypes.string,
+  user: PropTypes.object,
+  row: PropTypes.object
+};
+
+export default OwnershipTD;


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/152922036

![image](https://user-images.githubusercontent.com/999124/32892407-6b35a160-cad6-11e7-8aab-8d83835a9004.png)


Widgets and layers had already ownership column.