### PR TITLE
Improves the tooltip for the Vega charts

### DIFF
--- a/components/widgets/charts/VegaChart.js
+++ b/components/widgets/charts/VegaChart.js
@@ -142,12 +142,13 @@ class VegaChart extends React.Component {
       return config.label;
     };
 
-
     // If the cursor is on top of a mark, we display the data
     // associated to that mark
-    // The only exception is for the lines because the data
-    // they own is always the first one (first point)
-    if (!isEmpty(item) && item.datum.x && item.mark.marktype !== 'line') {
+    // The only exception is for the lines, areas and text because the
+    // data they own is always the first one (first point)
+    if (!isEmpty(item) && item.datum.x && item.mark.marktype !== 'line'
+      && item.mark.marktype !== 'area'
+      && item.mark.marktype !== 'text') {
       return this.props.toggleTooltip(true, {
         follow: true,
         direction: 'bottom',
@@ -173,8 +174,10 @@ class VegaChart extends React.Component {
 
     // If the chart doesn't have an x axis, if the data is undefined,
     // if the x value is null [1] or if the chart is a scatter plot [2],
-    // we don't determine the data to show in the tooltip depending
-    // on the x position of the cursor (based on the x scale)
+    // if the interaction_config object is not defined [3], if the data
+    // doesn't have "x" values [4], we don't determine the data to show
+    // in the tooltip depending on the x position of the cursor (based
+    // on the x scale)
     // We actually hide the tooltip
     //
     // [1] Null or undefined values can arise from the padding of
@@ -182,10 +185,16 @@ class VegaChart extends React.Component {
     // [2] As the scatter plot can have several points at the same
     //     x position, we want to avoid showing the data of a
     //     random point when not hovering a dot
+    // [3] Widgets created outside from the widget editor don't have
+    //     an interaction_config object
+    // [4] Same as [3]. We need an x value to be able to sort the data
+    //     for the bisect later on.
     const xAxis = vegaConfig.axes && vegaConfig.axes.find(axis => axis.type === 'x');
     const hasXAxis = !!(xAxis && (xAxis.real === undefined || xAxis.real));
     const isScatter = vegaConfig.marks.length === 1 && vegaConfig.marks[0].type === 'symbol';
-    if (!hasXAxis || !visData || x === undefined || x === null || isScatter) {
+    if (!hasXAxis || !visData || getTooltipConfigFields() === null
+      || (visData.length && visData[0].x === undefined)
+      || x === undefined || x === null || isScatter) {
       return this.props.toggleTooltip(false);
     }
 
@@ -216,6 +225,7 @@ class VegaChart extends React.Component {
     }
 
     if (data) {
+      const fields = getTooltipConfigFields().filter(f => f.key !== 'x');
       return this.props.toggleTooltip(true, {
         follow: true,
         direction: 'bottom',
@@ -228,12 +238,14 @@ class VegaChart extends React.Component {
               format: getFormat('x'),
               value: data.x
             },
-            y: {
-              type: getType('y', data.y),
-              label: getLabel('y'),
-              format: getFormat('y'),
-              value: data.y
-            }
+            ...fields.map(f => ({
+              [f.key]: {
+                type: getType(f.key, data[f.key]),
+                label: getLabel(f.key),
+                format: getFormat(f.key),
+                value: data[f.key]
+              }
+            })).reduce((res, field) => Object.assign({}, res, field), {})
           }
         }
       });

--- a/components/widgets/charts/VegaChartTooltip.js
+++ b/components/widgets/charts/VegaChartTooltip.js
@@ -25,41 +25,44 @@ class VegaChartTooltip extends React.Component {
     return x.value;
   }
 
-  getParsedY() {
-    const { item } = this.props;
-    if (!item) return null;
-
-    const { y } = item;
-    if (!y) return null;
-
-    if (y.format && y.type === 'number') {
-      return format(y.format)(y.value);
-    } else if (y.type === 'date') {
-      const date = new Date(y.value);
+  getParsedValue(field) { // eslint-disable-line class-methods-use-this
+    if (field.format && field.type === 'number') {
+      return format(field.format)(field.value);
+    } else if (field.type === 'date') {
+      const date = new Date(field.value);
       // NOTE: it's important to have a default format for
-      // the manually-created widgets, otherwise if y.format
+      // the manually-created widgets, otherwise if field.format
       // is not defined, time.format will return a date
       // object and the app will crash in dev environment
       // and the tooltip won't show in prod
-      const f = y.format || '%d %b %Y';
+      const f = field.format || '%d %b %Y';
       return time.format(f)(date);
     }
 
-    return y.value;
+    return field.value;
   }
 
 
   render() {
+    const fieldsName = Object.keys(this.props.item).filter(f => f !== 'x');
     return (
       <div className="c-chart-tooltip">
         { this.props.item.x.label && (
           <div className="labels">
-            { this.props.item.y.label && <span>{this.props.item.y.label}</span> }
+            { fieldsName.length && fieldsName.map(fieldName => (
+              this.props.item[fieldName].label
+                ? <span>{this.props.item[fieldName].label}</span>
+                : false
+            ))}
             <span>{this.props.item.x.label}</span>
           </div>
         )}
         <div className="values">
-          { this.props.item.y.value && <span>{this.getParsedY()}</span> }
+          { fieldsName.length && fieldsName.map(fieldName => (
+            this.props.item[fieldName].value
+              ? <span>{this.getParsedValue(this.props.item[fieldName])}</span>
+              : false
+          ))}
           <span>{this.getParsedX()}</span>
         </div>
       </div>
@@ -67,18 +70,15 @@ class VegaChartTooltip extends React.Component {
   }
 }
 
-const columnType = PropTypes.shape({
-  type: PropTypes.oneOf(['number', 'string', 'date']),
-  label: PropTypes.string,
-  format: PropTypes.string,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object])
-});
+// const columnType = PropTypes.shape({
+//   type: PropTypes.oneOf(['number', 'string', 'date']),
+//   label: PropTypes.string,
+//   format: PropTypes.string,
+//   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object])
+// });
 
 VegaChartTooltip.propTypes = {
-  item: PropTypes.shape({
-    x: columnType,
-    y: columnType
-  })
+  item: PropTypes.object
 };
 
 export default VegaChartTooltip;


### PR DESCRIPTION
This PR prevents displaying wrong values in the tooltip of the Vega charts and enable tooltips to display more than just the "x" and "y" values.

In details:
* Manually-created widgets won't display tooltips anymore, except if the user hovers a "compatible" marks **[1]**. This prevents showing incoherent values such as `NaN` or `0`.
* Through the `interaction_config` object, Vega specs can now define as many items as they want for the tooltip 

**[1]** Lines and areas are displayed as one mark along the x axis; texts are usually static. That's why they are not used to display a tooltip.

This PR fixes issues in My Prep for widgets created through the NexGDDP tool. The possibility to have several items at once in the tooltips will be used to display the values of each of the lines/areas of those widgets.

I'll submit a similar PR to Resource Watch since we share the same code for the `VegaChart` component.