### PR TITLE
Widget editor: fix mispositioned tooltip

### DIFF
--- a/css/index.scss
+++ b/css/index.scss
@@ -20,6 +20,7 @@
 @import '../node_modules/rc-slider/assets/index';
 @import '../node_modules/react-input-range/src/scss/index.scss';
 @import '../node_modules/react-redux-toastr/src/styles/index';
+@import '../node_modules/widget-editor/dist/styles.min';
 
 // Editor
 @import '../node_modules/react-quill/dist/quill.snow';
@@ -127,7 +128,6 @@
 
 
 // WIDGETS
-@import '../node_modules/widget-editor/dist/styles.min';
 @import "./components/widgets/add_widget_to_collection_tooltip";
 @import "./components/widgets/text_chart";
 @import "./components/widgets/widget_editor";

--- a/css/layouts/_container.scss
+++ b/css/layouts/_container.scss
@@ -1,6 +1,8 @@
 .l-container {
   width: 100%;
-  position: relative;
+  // NOTE: relative position break the tooltip of the widget editor
+  // do not de-comment the line without a solution for this
+  position: static; // We force the position to static to override some rule
   // max-width: $grid-row-width;
   margin: 0 auto;
   box-sizing: border-box;


### PR DESCRIPTION
This PR fixes an issue where the tooltip of the widget editor would be mispositioned.

The issue has been temporarily fixed forcing `.l-container` to a static position. The real issue comes from the fact the widget editor itself defines a class `.l-container` with a relative position. The change has been made to the editor but won't be released until v0.1.3. Meanwhile, we can override this rule.

To test the PR, go to `/myprep-detail/widgets/new?datasetId=85e95ef4-f1fe-4195-8ecd-99218bf00471` (or to any dataset you want). The tooltip should be correctly positioned when hovering a bar chart for example.

[Pivotal task](https://www.pivotaltracker.com/story/show/154850901)