### PR TITLE
Embeds: Fix a bug that prevented the metatada from showing

### DIFF
--- a/pages/app/embed/EmbedEmbed.js
+++ b/pages/app/embed/EmbedEmbed.js
@@ -57,7 +57,7 @@ class EmbedWidget extends Page {
 
   getModal() {
     const { widget } = this.props;
-    const { description, metadata } = widget;
+    const { description, metadata } = widget.attributes;
     const widgetLinks = ((metadata || []).length &&
       metadata[0].attributes.info &&
       metadata[0].attributes.info.widgetLinks) || [];

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -66,7 +66,7 @@ class EmbedMap extends Page {
 
   getModal() {
     const { widget } = this.props;
-    const { description, metadata } = widget;
+    const { description, metadata } = widget.attributes;
     const widgetLinks = ((metadata || []).length &&
       metadata[0].attributes.info &&
       metadata[0].attributes.info.widgetLinks) || [];

--- a/pages/app/embed/EmbedText.js
+++ b/pages/app/embed/EmbedText.js
@@ -57,7 +57,7 @@ class EmbedText extends Page {
 
   getModal() {
     const { widget } = this.props;
-    const { description, metadata } = widget;
+    const { description, metadata } = widget.attributes;
     const widgetLinks = ((metadata || []).length &&
       metadata[0].attributes.info &&
       metadata[0].attributes.info.widgetLinks) || [];

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -63,7 +63,7 @@ class EmbedWidget extends Page {
 
   getModal() {
     const { widget, bandDescription, bandStats } = this.props;
-    const { description, metadata } = widget;
+    const { description, metadata } = widget.attributes;
     const widgetLinks = ((metadata || []).length &&
       metadata[0].attributes.info &&
       metadata[0].attributes.info.widgetLinks) || [];

--- a/redactions/widget.js
+++ b/redactions/widget.js
@@ -210,7 +210,7 @@ export function getWidget(widgetId) {
   return (dispatch) => {
     dispatch({ type: GET_WIDGET_LOADING });
     const service = new WidgetService(widgetId, { apiURL: process.env.WRI_API_URL });
-    return service.fetchData()
+    return service.fetchData('metadata')
       .then((data) => {
         dispatch({ type: SET_WIDGET_DATA, payload: data });
         return data;


### PR DESCRIPTION
This PR fixes a bug where the Widget, Map, Text and Embed embeds wouldn't show the widget's description and links (if any).

You can test the fix with this link: `/embed/embed/eaf16acb-3ea1-4a3d-b749-4f622ac594aa` where you should see a link in the modal.