### PR TITLE
My Prep: the embed link would be wrong for the embed widgets

### DIFF
--- a/components/modal/EmbedMyWidgetModal.js
+++ b/components/modal/EmbedMyWidgetModal.js
@@ -22,12 +22,28 @@ class EmbedMyWidgetModal extends React.Component {
     }
   }
 
+  /**
+   * Return the type of embed
+   * @return {string}
+   */
+  getEmbedType() {
+    const { visualizationType } = this.props;
+
+    if (visualizationType === 'map') {
+      return 'map';
+    } else if (visualizationType === 'embed') {
+      return 'embed';
+    }
+
+    return 'widget';
+  }
+
   render() {
-    const { widget, visualizationType } = this.props;
+    const { widget } = this.props;
     const { id } = widget;
     const { protocol, hostname, port } = window && window.location ? window.location : {};
     const embedHost = window && window.location ? `${protocol}//${hostname}${port !== '' ? `:${port}` : port}` : '';
-    const url = `${embedHost}/embed/${visualizationType === 'map' ? 'map' : 'widget'}/${id}`;
+    const url = `${embedHost}/embed/${this.getEmbedType()}/${id}`;
     const iframeText = `<iframe src="${url}" width="100%" height="474" frameBorder="0"></iframe>`;
     return (
       <div className="c-embed-my-widget-modal">

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -332,8 +332,7 @@ class WidgetCard extends PureComponent {
       childrenProps: {
         widget: this.props.widget,
         visualizationType: (this.props.widget.widgetConfig
-          && this.props.widget.widgetConfig.paramsConfig
-          && this.props.widget.widgetConfig.paramsConfig.visualizationType)
+          && this.props.widget.widgetConfig.type)
           || 'chart',
         toggleModal: this.props.toggleModal
       }


### PR DESCRIPTION
This PR fixes an issue where the link to embed an "embed" widget would be wrong in My Prep. The link would be generated as if the widget was a Vega one, leading to the embed not working.