### PR TITLE
 [ON HOLD] Widget editor: Update to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,11 @@
         "through2": "2.0.3"
       }
     },
+    "@types/json-stable-stringify": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz",
+      "integrity": "sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw=="
+    },
     "@types/node": {
       "version": "6.0.88",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
@@ -2280,6 +2285,15 @@
         "units-css": "0.4.0"
       }
     },
+    "canvas-prebuilt": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/canvas-prebuilt/-/canvas-prebuilt-1.6.0.tgz",
+      "integrity": "sha1-+N2avoH9whA6Odg2LfMhnW2D94g=",
+      "optional": true,
+      "requires": {
+        "node-pre-gyp": "0.6.39"
+      }
+    },
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
@@ -3176,14 +3190,6 @@
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
       "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
     },
-    "d3-cloud": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-cloud/-/d3-cloud-1.2.4.tgz",
-      "integrity": "sha1-PhaUA62rdP2wyGdjjX8LuOaucf8=",
-      "requires": {
-        "d3-dispatch": "1.0.3"
-      }
-    },
     "d3-collection": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
@@ -3193,6 +3199,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
       "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
+    },
+    "d3-contour": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.1.2.tgz",
+      "integrity": "sha512-po2Gxab58NQMAaVLj1ruASkmHlB8JebFFhm2cDVs2JFjTv9AYZpRQEWMycLoP7JH530dBDl90HI30g5EnpTJfA==",
+      "requires": {
+        "d3-array": "1.2.1"
+      }
     },
     "d3-dispatch": {
       "version": "1.0.3",
@@ -3204,10 +3218,29 @@
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-0.1.14.tgz",
       "integrity": "sha1-mDPNYaWj6B4DJjoc54903lah27g="
     },
+    "d3-force": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
+      "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+      "requires": {
+        "d3-collection": "1.0.4",
+        "d3-dispatch": "1.0.3",
+        "d3-quadtree": "1.0.3",
+        "d3-timer": "1.0.7"
+      }
+    },
     "d3-format": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-0.4.2.tgz",
       "integrity": "sha1-qnWcHlquX6javJq3gZxQL8a1aHU="
+    },
+    "d3-geo": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
+      "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
+      "requires": {
+        "d3-array": "1.2.1"
+      }
     },
     "d3-geo-projection": {
       "version": "0.2.16",
@@ -3217,6 +3250,11 @@
         "brfs": "1.4.3"
       }
     },
+    "d3-hierarchy": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz",
+      "integrity": "sha1-ochFxC+Eoga88cAcAQmOpN2qeiY="
+    },
     "d3-interpolate": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
@@ -3225,19 +3263,51 @@
         "d3-color": "1.0.3"
       }
     },
+    "d3-path": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
+      "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
+    },
+    "d3-quadtree": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
+      "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg="
+    },
     "d3-queue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-2.0.3.tgz",
       "integrity": "sha1-B/vaOsrlNYqcUpmq+ICt8JU+0sI="
     },
+    "d3-request": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
+      "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
+      "requires": {
+        "d3-collection": "1.0.4",
+        "d3-dispatch": "1.0.3",
+        "d3-dsv": "1.0.8",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "d3-dsv": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
+          "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+          "requires": {
+            "commander": "2.8.1",
+            "iconv-lite": "0.4.15",
+            "rw": "1.3.3"
+          }
+        }
+      }
+    },
     "d3-scale": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.0.0.tgz",
+      "integrity": "sha512-Sa2Ny6CoJT7x6dozxPnvUQT61epGWsgppFvnNl8eJEzfJBG0iDBBTJAtz2JKem7Mb+NevnaZiDiIDHsuWkv6vg==",
       "requires": {
         "d3-array": "1.2.1",
         "d3-collection": "1.0.4",
-        "d3-color": "1.0.3",
         "d3-format": "1.2.2",
         "d3-interpolate": "1.1.6",
         "d3-time": "1.0.8",
@@ -3264,6 +3334,28 @@
         }
       }
     },
+    "d3-scale-chromatic": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.2.0.tgz",
+      "integrity": "sha512-qQUhLi8fPe/F0b0M46C6eFUbms5IIMHuhJ5DKjjzBUvm1b6aPtygJzGbrMdMUD/ckLBq+NdWwHeN2cpMDp4Q5Q==",
+      "requires": {
+        "d3-color": "1.0.3",
+        "d3-interpolate": "1.1.6"
+      }
+    },
+    "d3-selection": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+      "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
+    },
+    "d3-shape": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
+      "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
+      "requires": {
+        "d3-path": "1.0.5"
+      }
+    },
     "d3-time": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-0.1.1.tgz",
@@ -3276,6 +3368,16 @@
       "requires": {
         "d3-time": "0.1.1"
       }
+    },
+    "d3-timer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
+      "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
+    },
+    "d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
     },
     "damerau-levenshtein": {
       "version": "1.0.4",
@@ -12750,64 +12852,6 @@
         "react": "15.6.2"
       }
     },
-    "react-vega": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-vega/-/react-vega-2.3.1.tgz",
-      "integrity": "sha1-SkTDX9KGfaghVaIkybhXHmZURR4=",
-      "requires": {
-        "vega": "2.6.5"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "vega": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/vega/-/vega-2.6.5.tgz",
-          "integrity": "sha1-I3jUZyk0Igvilx3AhxqYflQstb4=",
-          "requires": {
-            "canvas": "1.6.7",
-            "d3": "3.5.17",
-            "d3-cloud": "1.2.4",
-            "d3-geo-projection": "0.2.16",
-            "datalib": "1.7.3",
-            "topojson": "1.6.27",
-            "vega-dataflow": "1.4.3",
-            "vega-event-selector": "1.1.0",
-            "vega-expression": "1.2.1",
-            "vega-logging": "1.0.2",
-            "vega-scenegraph": "1.1.0",
-            "yargs": "3.32.0"
-          }
-        },
-        "window-size": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "requires": {
-            "camelcase": "2.1.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
-          }
-        }
-      }
-    },
     "read-all-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
@@ -15247,6 +15291,14 @@
         "shapefile": "0.3.1"
       }
     },
+    "topojson-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
+      "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
+      "requires": {
+        "commander": "2.8.1"
+      }
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -15291,6 +15343,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+    },
+    "tslib": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -15601,24 +15658,40 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vega": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-2.6.3.tgz",
-      "integrity": "sha1-LN68CLO60YZrXYzMS7eMix9JNKo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-3.1.0.tgz",
+      "integrity": "sha512-ypSadmFqIxRaE0NvZI4XYrpZ+3iGSjUgXRsvyA2AO82ImbEvmUILpZZaHCSK/fIp71/q0BZY/InsfeHqK/jFrA==",
       "requires": {
         "canvas": "1.6.7",
-        "d3": "3.5.17",
-        "d3-cloud": "1.2.4",
-        "d3-geo-projection": "0.2.16",
-        "datalib": "1.7.3",
-        "topojson": "1.6.27",
-        "vega-dataflow": "1.4.3",
-        "vega-event-selector": "1.1.0",
-        "vega-expression": "1.2.1",
-        "vega-logging": "1.0.2",
-        "vega-scenegraph": "1.1.0",
-        "yargs": "3.32.0"
+        "canvas-prebuilt": "1.6.0",
+        "vega-crossfilter": "2.0.0",
+        "vega-dataflow": "3.0.5",
+        "vega-encode": "2.0.6",
+        "vega-expression": "2.3.1",
+        "vega-force": "2.0.0",
+        "vega-geo": "2.2.0",
+        "vega-hierarchy": "2.1.1",
+        "vega-loader": "2.0.4",
+        "vega-parser": "2.5.1",
+        "vega-projection": "1.0.1",
+        "vega-runtime": "2.0.1",
+        "vega-scale": "2.1.1",
+        "vega-scenegraph": "2.3.1",
+        "vega-statistics": "1.2.1",
+        "vega-transforms": "1.2.0",
+        "vega-util": "1.7.0",
+        "vega-view": "2.2.0",
+        "vega-view-transforms": "1.2.0",
+        "vega-voronoi": "2.0.0",
+        "vega-wordcloud": "2.1.0",
+        "yargs": "4.8.1"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -15630,58 +15703,464 @@
           }
         },
         "window-size": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
         },
         "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "requires": {
-            "camelcase": "2.1.1",
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "lodash.assign": "4.2.0",
             "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
             "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
           }
         }
       }
     },
-    "vega-dataflow": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-1.4.3.tgz",
-      "integrity": "sha1-GsX1is4DOYL/Q/EqDrJjps0rXis=",
+    "vega-canvas": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.0.1.tgz",
+      "integrity": "sha512-2ng3O+cOCRwDXqZ+kk1nkeBWCK7Z029dZUTj6wdl36VSEZbcnnsj7bVgwsxni/4k8EPSecIMUPSaCgCj7/llMQ=="
+    },
+    "vega-crossfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-2.0.0.tgz",
+      "integrity": "sha512-haSPtAcSv3TjwAQHLAv8xVB/GM1+lWgFIPmarPX6No/Mq0hewwKuYm2xDlp6zbKKyuDvpW3GzNmLMJfLvzat8A==",
       "requires": {
-        "datalib": "1.7.3",
-        "vega-logging": "1.0.2"
+        "d3-array": "1.2.1",
+        "vega-dataflow": "3.0.5",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-dataflow": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-3.0.5.tgz",
+      "integrity": "sha512-WhN9XUktJ9khB4qUUATn/2sY74/jScuiD5kPYOLd8VXnovPoLvPYGHq0FOqXSWsykFUV1/eQ8EdK2usf4pXoiQ==",
+      "requires": {
+        "vega-loader": "2.0.4",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-encode": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-2.0.6.tgz",
+      "integrity": "sha512-v07/uZvztAyeb/zyxuJZVxRJzKMM4xA4Ft4RRPllPp9JAqQjAvP9JN9TmswX5GtOdo7cR17+X6MSUqfwlSxMKA==",
+      "requires": {
+        "d3-array": "1.2.1",
+        "d3-format": "1.2.2",
+        "d3-interpolate": "1.1.6",
+        "vega-dataflow": "3.0.5",
+        "vega-scale": "2.1.1",
+        "vega-util": "1.7.0"
+      },
+      "dependencies": {
+        "d3-format": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
+          "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+        }
       }
     },
     "vega-event-selector": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-1.1.0.tgz",
-      "integrity": "sha1-fn6wIXuTQ7vZ3Yqek2323nSV24w="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.0.tgz",
+      "integrity": "sha512-EZeStM/7LNfJiRuop0lvhOR52Q1l9i/EIYUnm/XddhjR+UqhPkeCmZcffMTr41z3aGm/zciVLlKanUWNT+jQ1A=="
     },
     "vega-expression": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-1.2.1.tgz",
-      "integrity": "sha1-BaxDv/QzNLVzxi0wRIRk1rMqDs4="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-2.3.1.tgz",
+      "integrity": "sha512-BOf+7XuzsubcbiLJkgyvnywse1+NY72HhzFPQqwUIfloaH9U6m2sNfMhc353ODWF9UFpKXSQ9r4tWohTj64kNQ==",
+      "requires": {
+        "vega-util": "1.7.0"
+      }
     },
-    "vega-logging": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vega-logging/-/vega-logging-1.0.2.tgz",
-      "integrity": "sha1-wOt9QBPspTZ3gwdek1CMSlQNdEQ="
+    "vega-force": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-2.0.0.tgz",
+      "integrity": "sha512-pQ+r2E7kVRofo2+63jHv5P4qBcCoXHd6asi5HQ9zt4O9cncQ2HTmIfPPWpa6Cy4r8sBWXZHh80nyTuaV6awn8A==",
+      "requires": {
+        "d3-force": "1.1.0",
+        "vega-dataflow": "3.0.5",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-geo": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-2.2.0.tgz",
+      "integrity": "sha512-9KP7JViST3foDMUGIxZamzPtqE9V5iIWJcpAZryuGb5KpLSY7yZDuGinOnIxyn56RCX5URxp+RVLwBdeTR+33Q==",
+      "requires": {
+        "d3-array": "1.2.1",
+        "d3-contour": "1.1.2",
+        "d3-geo": "1.9.1",
+        "vega-dataflow": "3.0.5",
+        "vega-projection": "1.0.1",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-hierarchy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-2.1.1.tgz",
+      "integrity": "sha512-jw2OknF0ZH6A5QTWKYXOJn9jC5kr+dtkmAaq6kMocaseGwS1ScQDli2TOMtfple1ddsmPEl6fStuWWzwl0dgKw==",
+      "requires": {
+        "d3-collection": "1.0.4",
+        "d3-hierarchy": "1.1.5",
+        "vega-dataflow": "3.0.5",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-lite": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-2.1.3.tgz",
+      "integrity": "sha512-A8plB9akwmKEssf5Eqs1g0nqcYCxmbKv8PLL3TtBhFnJeJNhMlQXTrmTrRmgVAYqWkPTNh94ta1NcQrEytMaEg==",
+      "requires": {
+        "@types/json-stable-stringify": "1.0.32",
+        "json-stable-stringify": "1.0.1",
+        "tslib": "1.9.0",
+        "vega-event-selector": "2.0.0",
+        "vega-util": "1.7.0",
+        "yargs": "11.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "yargs": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+          "requires": {
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
+    "vega-loader": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-2.0.4.tgz",
+      "integrity": "sha512-WdPcAjRKH0rUzswQjzejxbQXPZId0PF4n2uw/YXAFJgvaxGaG1QXUWRk25XjvTFz5iHOsPFSzKynrO8ZzPaFsg==",
+      "requires": {
+        "d3-dsv": "1.0.8",
+        "d3-request": "1.0.6",
+        "d3-time-format": "2.1.1",
+        "topojson-client": "3.0.0",
+        "vega-util": "1.7.0"
+      },
+      "dependencies": {
+        "d3-dsv": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
+          "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
+          "requires": {
+            "commander": "2.8.1",
+            "iconv-lite": "0.4.15",
+            "rw": "1.3.3"
+          }
+        },
+        "d3-time": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
+          "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+        },
+        "d3-time-format": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
+          "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+          "requires": {
+            "d3-time": "1.0.8"
+          }
+        }
+      }
+    },
+    "vega-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-2.5.1.tgz",
+      "integrity": "sha512-4dBa+EN6c69KqM8N1wqBMIA20PqSLyBzLQ16e7/aWsvQhWgn2dNtxbE5V3nazX2VpMe6TNl0CFZeCoYGCmxnGw==",
+      "requires": {
+        "d3-array": "1.2.1",
+        "d3-color": "1.0.3",
+        "d3-format": "1.2.2",
+        "d3-geo": "1.9.1",
+        "d3-time-format": "2.1.1",
+        "vega-dataflow": "3.0.5",
+        "vega-event-selector": "2.0.0",
+        "vega-expression": "2.3.1",
+        "vega-scale": "2.1.1",
+        "vega-scenegraph": "2.3.1",
+        "vega-statistics": "1.2.1",
+        "vega-util": "1.7.0"
+      },
+      "dependencies": {
+        "d3-format": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
+          "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+        },
+        "d3-time": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
+          "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+        },
+        "d3-time-format": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
+          "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+          "requires": {
+            "d3-time": "1.0.8"
+          }
+        }
+      }
+    },
+    "vega-projection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.0.1.tgz",
+      "integrity": "sha512-NaXggPcCbrvfUl1roGPumU2aOCp7iDhP5lRkBXYy+Pnx6VH9mb9/xadBgSeKUjFJlPCS2SrOdHJ173ci1nhy5w==",
+      "requires": {
+        "d3-geo": "1.9.1"
+      }
+    },
+    "vega-runtime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-2.0.1.tgz",
+      "integrity": "sha512-IO4Rd75g2XAmQq3FCi7MqLUGM9CwLZRMeGsBftfjpYuWMgQUDK0xyIOD1qui/RzYVOiN/ENbnY6tPPKYPNhmtA==",
+      "requires": {
+        "vega-dataflow": "3.0.5",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-scale": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-2.1.1.tgz",
+      "integrity": "sha512-+Ag6366h/gqnrBtpWQpiyu0+ionPs/HBUPPZnsciidcrOB8sDpB9sU1ecz8nTw6rci05+VhDJeKwyRMHcMf7gQ==",
+      "requires": {
+        "d3-array": "1.2.1",
+        "d3-interpolate": "1.1.6",
+        "d3-scale": "2.0.0",
+        "d3-scale-chromatic": "1.2.0",
+        "d3-time": "1.0.8",
+        "vega-util": "1.7.0"
+      },
+      "dependencies": {
+        "d3-time": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
+          "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+        }
+      }
     },
     "vega-scenegraph": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-1.1.0.tgz",
-      "integrity": "sha1-qLkef+v25lf6NvqymE9jiEgQxmM=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-2.3.1.tgz",
+      "integrity": "sha512-DR0auOjbGtPxmfeWCuMn/vp2Qageh5vO53NDhD4+5f5Roghf7OH6esL9gvq5t+KIpAsESHmLX9nfbOk5rMGA+Q==",
       "requires": {
-        "canvas": "1.6.7",
-        "d3": "3.5.17",
-        "datalib": "1.7.3"
+        "d3-path": "1.0.5",
+        "d3-shape": "1.2.0",
+        "vega-canvas": "1.0.1",
+        "vega-loader": "2.0.4",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-statistics": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.2.1.tgz",
+      "integrity": "sha512-70CC6rbS1RFVEpKT/qOGHhHATeh92cB2gXnjg+zErrY8255cBlOW8X0s4iZBsoa4vibGXb42imyM+rxAwL1VPA==",
+      "requires": {
+        "d3-array": "1.2.1"
+      }
+    },
+    "vega-tooltip": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.5.1.tgz",
+      "integrity": "sha512-gYqD7hms0zmi0AoOi5+l7FPqJM8E980GPDUE0ejNB8nQAjJxO9b1ykxuaLvLZGNEL8l3d4vGBe+gfHxzgVpPYg==",
+      "requires": {
+        "d3-format": "1.2.2",
+        "d3-selection": "1.3.0",
+        "d3-time-format": "2.1.1",
+        "vega": "3.1.0",
+        "vega-lite": "2.1.3"
+      },
+      "dependencies": {
+        "d3-format": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.2.tgz",
+          "integrity": "sha512-zH9CfF/3C8zUI47nsiKfD0+AGDEuM8LwBIP7pBVpyR4l/sKkZqITmMtxRp04rwBrlshIZ17XeFAaovN3++wzkw=="
+        },
+        "d3-time": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
+          "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+        },
+        "d3-time-format": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
+          "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+          "requires": {
+            "d3-time": "1.0.8"
+          }
+        }
+      }
+    },
+    "vega-transforms": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-1.2.0.tgz",
+      "integrity": "sha512-SSb7whtpeUxeivwWk2AoU5CFeerXkTggM0h+ovo+mAIZnlmw9YUy4jL4/xDSRsq+XbgL9hC/bg/sztM1sYx46w==",
+      "requires": {
+        "d3-array": "1.2.1",
+        "vega-dataflow": "3.0.5",
+        "vega-statistics": "1.2.1",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-util": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.7.0.tgz",
+      "integrity": "sha512-IlmYqW0t3UP8AJX4QuOOm5cMPKPOUa8fSTcCvNkfVOR5zvMNFKCVhoZmJSXgcbEhkfboB+ysI2aaWOeW2kKBog=="
+    },
+    "vega-view": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-2.2.0.tgz",
+      "integrity": "sha512-UW9CqqFw2NL3MiBoONAbGbTUN8wQRRHjikuJ84Y7tCebfzhxzVzntStB49TahCvPmYo5vaNPlQnmmi1jwA5hsQ==",
+      "requires": {
+        "d3-array": "1.2.1",
+        "vega-dataflow": "3.0.5",
+        "vega-parser": "2.5.1",
+        "vega-runtime": "2.0.1",
+        "vega-scenegraph": "2.3.1",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-view-transforms": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-1.2.0.tgz",
+      "integrity": "sha512-O68gPTfT2/lDnLabHWG1hg33fUAMHElfOkVnboQmuWw+OWN8GZh6S8Wvn8v+lLHpTlzgD0OlgcIIo/8GaoWJeA==",
+      "requires": {
+        "vega-dataflow": "3.0.5",
+        "vega-scenegraph": "2.3.1",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-voronoi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-2.0.0.tgz",
+      "integrity": "sha512-qM6f4RMebKJoOVTw5+/qeFf5FlzVdSV95n+z17MAFBFNwUsTr3luRROR8OAbMlPuUegeavlKeJQLajbQAhH9AA==",
+      "requires": {
+        "d3-voronoi": "1.1.2",
+        "vega-dataflow": "3.0.5",
+        "vega-util": "1.7.0"
+      }
+    },
+    "vega-wordcloud": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-2.1.0.tgz",
+      "integrity": "sha512-5kKjcse73d72OM1rBqWcbOpWKQeZrk/oVOxAG7EkGyElWQ+vIHBwj5qE4XYa1oIhhez25X1PVqhbzGMj1ZuKoQ==",
+      "requires": {
+        "vega-canvas": "1.0.1",
+        "vega-dataflow": "3.0.5",
+        "vega-scale": "2.1.1",
+        "vega-statistics": "1.2.1",
+        "vega-util": "1.7.0"
       }
     },
     "verror": {
@@ -16820,33 +17299,32 @@
       }
     },
     "widget-editor": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-0.1.2.tgz",
-      "integrity": "sha1-pHXMSk6j9af0RiSmDtZUs5VHyMg=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-1.0.0.tgz",
+      "integrity": "sha1-wClpFGNKzJQkl0QpK6gJo+ilbks=",
       "requires": {
         "autobind-decorator": "2.1.0",
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
-        "d3-array": "1.2.1",
         "d3-format": "1.2.2",
-        "d3-scale": "1.0.7",
         "d3-time-format": "2.1.1",
-        "esri-leaflet": "2.1.2",
+        "esri-leaflet": "2.1.3",
         "lodash": "4.17.4",
         "peer-deps-externals-webpack-plugin": "1.0.2",
         "prop-types": "15.6.0",
         "rc-slider": "8.6.0",
         "react-dnd": "2.5.4",
         "react-dnd-html5-backend": "2.5.4",
-        "react-dropzone": "4.2.7",
+        "react-dropzone": "4.2.8",
         "react-input-autosize": "2.0.1",
         "react-input-range": "1.2.2",
-        "react-redux": "5.0.6",
-        "react-redux-toastr": "7.2.1",
+        "react-redux": "5.0.7",
+        "react-redux-toastr": "7.2.3",
         "react-select": "1.2.1",
         "react-sortable-hoc": "0.6.8",
         "react-tether": "0.6.1",
-        "toastr": "2.1.4"
+        "toastr": "2.1.4",
+        "vega-tooltip": "0.5.1"
       },
       "dependencies": {
         "autobind-decorator": {
@@ -16893,19 +17371,27 @@
           }
         },
         "esri-leaflet": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-2.1.2.tgz",
-          "integrity": "sha512-hyCZI9/KxbDTjxO5MDbZjQIYVhGRTKkTkCTiMJyB02bqBNS6bM2MAxz7iW3u4JRKqhLziSfnVDNx3cMYUQs1zg==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-2.1.3.tgz",
+          "integrity": "sha512-9nVLLOKj987xlCknay7FybqM3ZBvqpgs5cHvURwadcSejC1Lnq2xgD9xrgjs5aQ4i2cv8MYdDy93Q2EX49PZ8g==",
           "requires": {
             "@esri/arcgis-to-geojson-utils": "1.0.5",
-            "leaflet-virtual-grid": "1.0.4",
+            "leaflet-virtual-grid": "1.0.5",
             "tiny-binary-search": "1.0.2"
           }
         },
         "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-          "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+        },
+        "leaflet-virtual-grid": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/leaflet-virtual-grid/-/leaflet-virtual-grid-1.0.5.tgz",
+          "integrity": "sha512-S4lcMOTGYjDUinAAM5xz65miEWHWI+WQo7V/vOVlos4Jn2jAZiQomMGu/MIZS7KrFGx33GDVaOYAx0wnV92NBA==",
+          "requires": {
+            "leaflet": "1.0.3"
+          }
         },
         "prop-types": {
           "version": "15.6.0",
@@ -16938,26 +17424,25 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "prop-types": "15.6.0",
-            "rc-trigger": "2.3.3"
+            "rc-trigger": "2.3.4"
           }
         },
         "rc-trigger": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.3.3.tgz",
-          "integrity": "sha512-j8MHq0jES4vXShFbSExyty/WVR238lrZzUfsSaIDeiziBIiUAOP6SR2HBEi2gSGK239Jm3bWIJvwGA85kFMgmQ==",
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.3.4.tgz",
+          "integrity": "sha512-xPhda3SfGWHywEbVJu2VxpWg99ELStzNPcdnxb7lZ9XwUnHjUeX9KCaIbJa9GUuoVHx3mQP1s2m3ttIB8aashQ==",
           "requires": {
             "babel-runtime": "6.26.0",
-            "create-react-class": "15.6.2",
             "prop-types": "15.6.0",
             "rc-align": "2.3.4",
             "rc-animate": "2.4.1",
-            "rc-util": "4.3.1"
+            "rc-util": "4.4.0"
           },
           "dependencies": {
             "rc-util": {
-              "version": "4.3.1",
-              "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.3.1.tgz",
-              "integrity": "sha512-OVNMKLePnwn0dCX/Gpc+/kGEDpmMo1Rfesg9xFcAckRd+D+YwVqV+dUJMHugP+4nRtbXi55o0HwPlkKIApYfQA==",
+              "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.4.0.tgz",
+              "integrity": "sha512-PIWw9VBjLc2m4GZBPxMFT3QaOIMQ0PdzMjAs02nQ3RSPDt6oLzZ+rMBzN1AxcNkkpBbz0Zmdg3llZGzYraWFew==",
               "requires": {
                 "add-dom-event-listener": "1.0.2",
                 "babel-runtime": "6.26.0",
@@ -16982,7 +17467,7 @@
           "requires": {
             "disposables": "1.0.1",
             "dnd-core": "2.5.4",
-            "hoist-non-react-statics": "2.3.1",
+            "hoist-non-react-statics": "2.5.0",
             "invariant": "2.2.2",
             "lodash": "4.17.4",
             "prop-types": "15.6.0"
@@ -16997,31 +17482,43 @@
           }
         },
         "react-dropzone": {
-          "version": "4.2.7",
-          "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-4.2.7.tgz",
-          "integrity": "sha512-BGEc/UtG0rHBEZjAkGsajPRO85d842LWeaP4CINHvXrSNyKp7Tq7s699NyZwWYHahvXaUNZzNJ17JMrfg5sxVg==",
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-4.2.8.tgz",
+          "integrity": "sha512-L/q6ySfhdG9Md3P21jFumzlm92TxRT0FtYX6G793Nf8bt7Fzpwx6gJsPk0idV094koj/Y5vRpp0q9+e0bdsjxw==",
           "requires": {
             "attr-accept": "1.1.0",
             "prop-types": "15.6.0"
           }
         },
         "react-redux": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-          "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+          "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
           "requires": {
-            "hoist-non-react-statics": "2.3.1",
+            "hoist-non-react-statics": "2.5.0",
             "invariant": "2.2.2",
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
+            "lodash": "4.17.5",
+            "lodash-es": "4.17.5",
             "loose-envify": "1.3.1",
             "prop-types": "15.6.0"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.5",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+              "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+            },
+            "lodash-es": {
+              "version": "4.17.5",
+              "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
+              "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+            }
           }
         },
         "react-redux-toastr": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/react-redux-toastr/-/react-redux-toastr-7.2.1.tgz",
-          "integrity": "sha512-ueOOBlbuknwHRhTko+ZZ3hophfNeXvXWJ/LdpuxbZ9iIOv4As4LkD+WsCZmbuLT6dc2i2/Iw8/j4wBPBr9qyJg==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/react-redux-toastr/-/react-redux-toastr-7.2.3.tgz",
+          "integrity": "sha512-iBlflWlksjF7+RlJpqOGQE2syRu1qBDUnloflB4Y7YbYgtb77Xgi32e9UhHItNjxPpcCP/skOWsRWs7D8KTrUw==",
           "requires": {
             "classnames": "2.2.5",
             "eventemitter3": "2.0.3",
@@ -17219,6 +17716,11 @@
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "react-tether": "0.5.7",
     "react-tokeninput": "2.4.0",
     "react-upload-file": "2.0.0-beta.6",
-    "react-vega": "2.3.1",
     "redis": "2.8.0",
     "redux": "3.6.0",
     "redux-devtools-extension": "2.13.2",
@@ -103,11 +102,11 @@
     "sqlite3": "3.1.8",
     "three": "0.83.0",
     "url-loader": "0.5.8",
-    "vega": "2.6.3",
+    "vega": "3.1.0",
     "vizz-wysiwyg": "1.1.9",
     "webpack": "^3.6.0",
     "whatwg-fetch": "2.0.2",
-    "widget-editor": "0.1.3"
+    "widget-editor": "1.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",


### PR DESCRIPTION
This PR updates [widget-editor](https://www.npmjs.com/package/widget-editor) to v1.0.0 and [vega](https://www.npmjs.com/package/vega) to v3.1.0.

This branch is not ready to be merged until all Prep's widgets have been migrated to Vega 3.

If you want to create some widgets to test it, please include `[Vega 3]` in the title of the chart so we don't have false positives while migrating the existing widgets.