### PR TITLE
Align delete button for resources based with API specifications

### DIFF
--- a/components/app/myprep/datasets/DatasetWidgets.js
+++ b/components/app/myprep/datasets/DatasetWidgets.js
@@ -145,7 +145,6 @@ class DatasetWidgets extends React.Component {
               onWidgetClick={this.handleClickWidget}
               onWidgetRemove={this.handleWidgetRemoved}
               showActions
-              showRemove
             />
             }
             {widgets && widgets.length === 0 &&

--- a/components/app/myprep/datasets/pages/my-prep-datasets/dataset-list/dataset-list-card-component.js
+++ b/components/app/myprep/datasets/pages/my-prep-datasets/dataset-list/dataset-list-card-component.js
@@ -40,6 +40,12 @@ class DatasetsListCard extends PureComponent {
     return dataset.name;
   }
 
+  canUserRemove = (user={}, dataset) => {
+    if (!user.role) return;
+    const userRole = user.role.toLowerCase();
+    return (userRole === 'admin') || (userRole === 'manager' && user.id === dataset.userId);
+  };
+
   handleDelete = () => {
     const { dataset } = this.props;
     this.props.onDatasetRemoved(dataset);
@@ -115,7 +121,7 @@ class DatasetsListCard extends PureComponent {
             }
           </div>
 
-          { (dataset.userId === user.id) &&
+          { this.canUserRemove(user, dataset) &&
             <div className="actions">
               <a
                 role="button"

--- a/components/app/myprep/widgets/my-prep-widgets/my-prep-widgets-component.js
+++ b/components/app/myprep/widgets/my-prep-widgets/my-prep-widgets-component.js
@@ -137,7 +137,6 @@ class MyPREPWidgets extends PureComponent {
                 mode={mode}
                 onWidgetRemove={this.handleWidgetRemoved}
                 showActions
-                showRemove
                 onWidgetClick={this.handleWidgetClick}
               />}
             {!!total && <Paginator

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -64,6 +64,12 @@ class WidgetCard extends PureComponent {
     return text;
   }
 
+  static canUserRemove(user, widget) {
+    const userRole = user.role.toLowerCase();
+
+    return (userRole === 'admin') || (userRole === 'manager' && user.id === widget.userId);
+  };
+
   /**
    * Return whether the widget represents a map
    * @static
@@ -472,7 +478,7 @@ class WidgetCard extends PureComponent {
                   Widget actions
                 </button>
               }
-              {showRemove && (widget.userId === user.id) &&
+              {WidgetCard.canUserRemove(user, widget) &&
                 <button
                   className="c-button -tertiary"
                   onClick={this.handleRemoveWidget}

--- a/components/widgets/list/WidgetList.js
+++ b/components/widgets/list/WidgetList.js
@@ -9,14 +9,12 @@ import WidgetCard from 'components/widgets/list/WidgetCard';
 class WidgetList extends PureComponent {
   static defaultProps = {
     showActions: false,
-    showRemove: false,
     showEmbed: false
   }
 
   static propTypes = {
     widgets: PropTypes.array.isRequired,
     showActions: PropTypes.bool,
-    showRemove: PropTypes.bool,
     showEmbed: PropTypes.bool,
     showFavourite: PropTypes.bool,
     loading: PropTypes.bool,
@@ -30,7 +28,6 @@ class WidgetList extends PureComponent {
   render() {
     const {
       widgets,
-      showRemove,
       showActions,
       showEmbed,
       showFavourite,
@@ -61,7 +58,6 @@ class WidgetList extends PureComponent {
                 onWidgetClick={this.props.onWidgetClick}
                 onWidgetRemove={this.handleWidgetRemoved}
                 showActions={showActions}
-                showRemove={showRemove}
                 showEmbed={showEmbed}
                 showFavourite={showFavourite}
                 mode={mode === 'grid' ? 'thumbnail' : 'full'}


### PR DESCRIPTION
Closes https://www.pivotaltracker.com/story/show/155547045

*Note:* Added for dataset as well as widget.
*API conditions:*

- User `role` as `admin` can delete everything
- User `role` as `manager` can only delete their own
- User `role` as `user` can't delete anything

*Tested for user and admin*