### PR TITLE
Widget: Fix widget editor button and column box styling

### DIFF
--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -20,9 +20,27 @@
   .c-we-columnbox {
     color: $charcoal-grey;
     background-color: $yellow;
+    padding-right: 3px;
 
     .c-we-icon { fill: $charcoal-grey; }
-    .order-by { color: $charcoal-grey; }
+
+    .order-by {
+      color: $charcoal-grey;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 20px;
+      margin-left: 4px;
+    }
+
+    .aggregate-function {
+      color: $base-font-color;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 20px;
+      margin-left: 4px;
+    }
   }
 
   .c-we-column-container {
@@ -111,6 +129,7 @@
   .c-we-button,
   .c-we-btn {
     @extend .c-button;
+    flex-direction: column;
 
     &.-primary {
       color: $white;


### PR DESCRIPTION
Closes https://www.pivotaltracker.com/story/show/155624452 (for Prep-manager)

**Fixes:**
- Vertical center compressed button text
- Fix layout of column box content

![image](https://user-images.githubusercontent.com/8505382/36975231-be99f7d6-2079-11e8-9e2a-4f3de1a23382.png)

