### PR TITLE
Admin: Set geoInfo checkbox by hidden input for a new raster dataset

### DIFF
--- a/components/datasets/form/steps/Step1.js
+++ b/components/datasets/form/steps/Step1.js
@@ -208,23 +208,25 @@ class Step1 extends React.Component {
             </Field>
           }
 
-          <Field
-            ref={(c) => { if (c) FORM_ELEMENTS.elements.geoInfo = c; }}
-            onChange={value => this.props.onChange({ geoInfo: value.checked })}
-            validations={['required']}
-            properties={{
-              name: 'geoInfo',
-              label: 'Does this dataset contain geographical features such as points, polygons or lines?',
-              value: 'geoInfo',
-              title: 'Yes',
-              disabled: (this.state.form.type === 'raster'),
-              defaultChecked: this.props.form.geoInfo,
-              checked: this.props.form.geoInfo
-            }}
-          >
-            {Checkbox}
-          </Field>
-
+          { (this.state.form.type === 'raster') ?
+            <input id="geoInfo" name="geoInfo" type="hidden" value="geoInfo" />
+            :
+            <Field
+              ref={(c) => { if (c) FORM_ELEMENTS.elements.geoInfo = c; }}
+              onChange={value => this.props.onChange({ geoInfo: value.checked })}
+              validations={['required']}
+              properties={{
+                name: 'geoInfo',
+                label: 'Does this dataset contain geographical features such as points, polygons or lines?',
+                value: 'geoInfo',
+                title: 'Yes',
+                defaultChecked: this.props.form.geoInfo,
+                checked: this.props.form.geoInfo
+              }}
+            >
+              {Checkbox}
+            </Field>
+          }
 
           <Field
             ref={(c) => { if (c) FORM_ELEMENTS.elements.provider = c; }}


### PR DESCRIPTION
Closes: https://www.pivotaltracker.com/story/show/155401865

For a raster dataset below input changed to a `hidden` input with value.

![image](https://user-images.githubusercontent.com/8505382/36983590-0710c012-2093-11e8-93cd-fbb9f2c23240.png)
