### PR TITLE
Prep Manager: Adds separate route for exporting widget to pdf

### DIFF
--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -365,11 +365,12 @@ class WidgetCard extends PureComponent {
     const id = this.props.widget.id;
     const type = this.props.widget.widgetConfig.type || 'widget';
     const { origin } = window.location;
+    const path = type.toLowerCase() === 'embed' ? 'export' : 'embed';
     const filename = encodeURIComponent(this.props.widget.name);
 
     const link = document.createElement('a');
     link.setAttribute('download', '');
-    link.href = `${process.env.CONTROL_TOWER_URL}/v1/webshot/pdf?filename=${filename}&width=790&height=580&waitFor=8000&url=${origin}/embed/${type}/${id}`;
+    link.href = `${process.env.CONTROL_TOWER_URL}/v1/webshot/pdf?filename=${filename}&width=790&height=580&waitFor=8000&url=${origin}/${path}/${type}/${id}`;
 
     // link.click() doesn't work on Firefox for some reasons
     // so we have to create an event manually

--- a/css/components/app/pages/export/export-widget.scss
+++ b/css/components/app/pages/export/export-widget.scss
@@ -1,0 +1,186 @@
+/*
+  This is the general layout of a widget:
+
+  +----------------------------------+
+  |      .widget-title (auto ↕)      |
+  +----------------------------------+
+  |                                  |
+  |     .widget-content (grow ↕)     |
+  |                                  |
+  +----------------------------------+
+  |     .widget-footer (auto ↕)      |
+  +----------------------------------+
+
+*/
+
+
+.c-export-widget {
+  position: relative; // Limit the scope of the map and spinner
+
+  // We use all the space available of the
+  // iframe and prevent any scroll
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+
+  // We share the vertical space between
+  // the title and the widget
+  display: flex;
+  flex-direction: column;
+
+  border: 1px solid $border-color-1;
+  border-radius: 4px;
+
+  .widget-title {
+    position: relative;
+    flex-shrink: 0;
+    padding: $margin-size-extra-small;
+    border-bottom: 1px solid $border-color-1;
+
+    h1, h2, h3, h4 {
+      display: inline-block;
+      margin-bottom: 0;
+      padding-right: 20px;
+    }
+
+    .buttons {
+      position: absolute;
+      top: #{$margin-size-extra-small + 4px};
+      right: $margin-size-extra-small;
+      margin: 0;
+      padding: 0;
+
+      button {
+        cursor: pointer;
+      }
+    }
+  }
+
+  .widget-info {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .widget-content {
+    position: relative;
+    display: flex; // Do not change this without testing (see comment on .c-map)
+    align-items: stretch;
+    flex-grow: 1;
+    padding: $margin-size-extra-small;
+    overflow: hidden;
+    flex-direction: column;
+
+    &.-external {
+      .c-map { // Do not change this without testing (see comment on .c-map)
+        height: calc(100% - #{$margin-size-extra-small});
+      }
+    }
+
+    .c-we-chart {
+      width: 100%;
+      height: auto; // Do not change this without testing (see comment on .c-map)
+      display: flex;
+      flex-direction: column;
+      // In case of a bar chart with scrolling, we need
+      // to use an overflow
+      overflow-x: auto;
+      max-width: 100%;
+
+      .chart {
+        height: 100%;
+
+        .vega {
+          height: 100%;
+
+          canvas {
+            display: block; // Prevent a UA margin
+            margin: 0 auto;
+          }
+        }
+      }
+    }
+
+    .c-map {
+      // Do not change the positionning of this
+      // element without testing it on Chrome and Firefox
+      // in the dashboards AND as a standalone widget
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+
+      // Without this property, the legend is hidden behind
+      // the map
+      .leaflet-pane {
+        z-index: 1;
+      }
+    }
+
+    .widget-modal {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      padding: $margin-size-extra-small;
+      z-index: 3;
+      background-color: $white;
+      overflow-x: hidden;
+      overflow-y: auto;
+
+      > div {
+        margin-bottom: $margin-size-extra-small;
+      }
+
+      h4 {
+        color: $base-font-color;
+      }
+    }
+
+    iframe {
+      width: 100%;
+      height: 500px;
+      border: 0;
+    }
+  }
+
+  .widget-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-shrink: 0;
+    padding: 0 $margin-size-extra-small $margin-size-extra-small;
+
+    .prep-logo {
+      display: block;
+      height: 30px;
+    }
+
+    .embed-logo {
+      display: block;
+      height: 21px;
+    }
+  }
+
+  .c-table {
+    position: relative;
+    min-height: 100px;
+
+    table {
+      display: block;
+      width: 100%;
+      font-size: $font-size-normal;
+
+      thead, tbody, tr {
+        display: block;
+        width: 100%;
+      }
+
+      th, td {
+        display: inline-block;
+        width: calc(100% / 6);
+      }
+    }
+  }
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -234,5 +234,8 @@
 @import "./components/app/pages/embed/embed_layer";
 @import "./components/app/pages/embed/embed_table";
 
+// Export
+@import "./components/app/pages/export/export-widget";
+
 // Subscriptions
 @import "./components/app/subscriptions/subscription_card";

--- a/pages/app/export/ExportEmbed.js
+++ b/pages/app/export/ExportEmbed.js
@@ -1,0 +1,212 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Redux
+import withRedux from 'next-redux-wrapper';
+import { initStore } from 'store';
+import { bindActionCreators } from 'redux';
+import { getWidget } from 'redactions/widget';
+import { setEmbed } from 'redactions/common';
+
+// Components
+import Page from 'components/app/layout/Page';
+import EmbedLayout from 'components/app/layout/EmbedLayout';
+import Spinner from 'components/ui/Spinner';
+import Icon from 'components/ui/Icon';
+
+class EmbedWidget extends Page {
+  static propTypes = {
+    widget: PropTypes.object,
+    getWidget: PropTypes.func,
+    loading: PropTypes.bool,
+    error: PropTypes.string
+  }
+
+  static defaultProps = {
+    widget: {}
+  }
+
+  static async getInitialProps(context) {
+    const props = await super.getInitialProps(context);
+    const { store, isServer, req } = context;
+
+    store.dispatch(setEmbed(true));
+
+    return {
+      ...props,
+      referer: isServer ? req.headers.referer : location.href
+    };
+  }
+
+  isLoadedExternally() {
+    return !/localhost|staging.resourcewatch.org/.test(this.props.referer);
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: props.isLoading
+    };
+  }
+
+  componentDidMount() {
+    const { url } = this.props;
+    this.props.getWidget(url.query.id, 'metadata');
+  }
+
+  render() {
+    const { widget, loading, error } = this.props;
+    const { isLoading } = this.state;
+
+    const { description, metadata } = widget.attributes ? widget.attributes: {};
+    const widgetLinks = ((metadata || []).length &&
+    metadata[0].attributes.info &&
+    metadata[0].attributes.info.widgetLinks) || [];
+    const noAdditionalInfo = !description && !widgetLinks.length;
+
+    if (loading) {
+      return (
+        <EmbedLayout
+          title="Loading widget..."
+          description=""
+        >
+          <div className="c-embed-widget">
+            <Spinner isLoading className="-light" />
+          </div>
+        </EmbedLayout>
+      );
+    }
+
+    if (error) {
+      return (
+        <EmbedLayout
+          title="Partnership for Resilience and Preparedness"
+          description=""
+        >
+          <div className="c-embed-widget">
+            <div className="widget-title">
+              <h4>–</h4>
+            </div>
+
+            <div className="widget-content">
+              <p>{'Sorry, the widget couldn\'t be loaded'}</p>
+            </div>
+
+            { this.isLoadedExternally() && (
+              <div className="widget-footer">
+                <a href="/" target="_blank" rel="noopener noreferrer">
+                  <img
+                    className="prep-logo"
+                    src={'/static/images/logo-blue@2x.png'}
+                    alt="Partnership for Resilience and Preparedness"
+                  />
+                </a>
+                <div>
+                  Powered by
+                  <a href="http://www.resourcewatch.org/" target="_blank" rel="noopener noreferrer">
+                    <img
+                      className="embed-logo"
+                      src={'/static/images/logo-embed.png'}
+                      alt="Resource Watch"
+                    />
+                  </a>
+                </div>
+              </div>
+            ) }
+          </div>
+        </EmbedLayout>
+      );
+    }
+
+    return (
+      <EmbedLayout
+        title={`${widget.attributes.name}`}
+        description={`${widget.attributes.description || ''}`}
+      >
+        <div className="c-export-widget">
+          <Spinner isLoading={isLoading} className="-light" />
+          <div className="widget-title">
+            {widgetLinks.length === 0 &&
+              <a href={`/dataset/${widget.attributes.dataset}`} target="_blank" rel="noopener noreferrer">
+                <h4>{widget.attributes.name}</h4>
+              </a>
+            }
+            {widgetLinks.length > 0 &&
+              <h4>{widget.attributes.name}</h4>
+            }
+          </div>
+          <div className="widget-content">
+            <iframe title={widget.attributes.name} src={widget.attributes.widgetConfig.url} />
+
+            <div className="widget-info">
+              <h4><Icon name="icon-info" className="c-icon -small" /> Information</h4>
+              { noAdditionalInfo &&
+                <p>No additional information is available</p>
+              }
+
+              { widgetLinks.length > 0 &&
+                <div className="widget-links-container">
+                  <h4>Links</h4>
+                  <ul>
+                    { widgetLinks.map(link => (
+                      <li key={link.link}>
+                        <a
+                          href={link.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {link.name}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              }
+
+              { description && (
+                <div>
+                  <h4>Description</h4>
+                  <p>{description}</p>
+                </div>
+              ) }
+            </div>
+
+          </div>
+          { this.isLoadedExternally() && (
+            <div className="widget-footer">
+              <a href="/" target="_blank" rel="noopener noreferrer">
+                <img
+                  className="prep-logo"
+                  src={'/static/images/logo-blue@2x.png'}
+                  alt="Partnership for Resilience and Preparedness"
+                />
+              </a>
+              <div>
+                Powered by
+                <a href="http://www.resourcewatch.org/" target="_blank" rel="noopener noreferrer">
+                  <img
+                    className="embed-logo"
+                    src={'/static/images/logo-embed.png'}
+                    alt="Resource Watch"
+                  />
+                </a>
+              </div>
+            </div>
+          ) }
+        </div>
+      </EmbedLayout>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  widget: state.widget.data,
+  loading: state.widget.loading,
+  error: state.widget.error
+});
+
+const mapDispatchToProps = dispatch => ({
+  getWidget: bindActionCreators(getWidget, dispatch)
+});
+
+export default withRedux(initStore, mapStateToProps, mapDispatchToProps)(EmbedWidget);

--- a/routes.js
+++ b/routes.js
@@ -49,5 +49,8 @@ routes.add('embed_dataset', '/embed/dataset/:id', 'app/embed/EmbedDataset');
 routes.add('embed_table', '/embed/table', 'app/embed/EmbedTable');
 routes.add('embed_dashboard', '/embed/dashboard/:slug', 'app/embed/EmbedDashboard');
 
+// ------ PDF EXPORT -------------
+routes.add('export_ember', '/export/embed/:id', 'app/export/ExportEmbed');
+
 
 module.exports = routes;


### PR DESCRIPTION
Towards https://www.pivotaltracker.com/story/show/155779300

This PR represents the `prep-manager` pdf layout of the component of this task, and configures the widget:

- [x] Widget title
- [x] Formatted widget information (not in a tooltip)
- [x] Map height

@davidsingal to confirm approach - because this widget export page is reliant on an `iframe` for the map, it will be necessary to create a new export variant of the explore embed in `prep-app` to complete this task (remove map controls, open legend by default).

**Note:** challenges testing because not on staging.