### PR TITLE
Dashboard detail: Fix map label indexing to be above layers

### DIFF
--- a/components/widgets/editor/map/Map.js
+++ b/components/widgets/editor/map/Map.js
@@ -195,7 +195,7 @@ class Map extends React.Component {
     if (enabled) {
       this.labelLayer = L.tileLayer(LABELS.value, LABELS.options || {})
         .addTo(this.map)
-        .setZIndex(this.props.layerGroups.length + 1);
+        .setZIndex(1001);
     }
   }
 


### PR DESCRIPTION
Closes https://www.pivotaltracker.com/story/show/155978665