### PR TITLE
Support for embed widgets in the dashboards

### DIFF
--- a/components/dashboards/wysiwyg/widget-block/widget-block-component.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-component.js
@@ -151,6 +151,14 @@ export default function WidgetBlock({
           </div>
         )}
 
+        {!widgetError && widgetType === 'embed' && widget.widgetConfig && widget && (
+          <iframe
+            title={widget.name}
+            src={widget.widgetConfig.url}
+            frameBorder="0"
+          />
+        )}
+
         {!widgetError && !layersError && !item && !item.content.widgetId &&
           <div className="message">
             <div className="no-data">No data</div>


### PR DESCRIPTION
The dashboards weren't able to display embed widgets. This prevented the users from displaying widgets from the NexGDDP tool in their dashboards.

[Pivotal task 1](https://www.pivotaltracker.com/story/show/155198448)
[Pivotal task 2](https://www.pivotaltracker.com/story/show/154262614)

_EDITED: the API bug has been fixed_
_EDITED 2: added other task reporting the same problem_