### PR TITLE
Update embed iframe url to export path for generated pdf downloads

### DIFF
--- a/pages/app/export/ExportEmbed.js
+++ b/pages/app/export/ExportEmbed.js
@@ -136,7 +136,7 @@ class EmbedWidget extends Page {
             }
           </div>
           <div className="widget-content">
-            <iframe title={widget.attributes.name} src={widget.attributes.widgetConfig.url} />
+            <iframe title={widget.attributes.name} src={widget.attributes.widgetConfig.url.replace('/embed/', '/export/')} />
 
             <div className="widget-info">
               <h4><Icon name="icon-info" className="c-icon -small" /> Information</h4>


### PR DESCRIPTION
Closes: https://www.pivotaltracker.com/story/show/155948220, https://www.pivotaltracker.com/story/show/155199374

@davidsingal is this a reasonable solution for specifying the `export` path for pdf downloads. I see that `widgetConfig` where the `url` property is comes from a fetch and is part of the the widget `attributes` and therefore can't change?