### PR TITLE
Let the user pick topics and geographies tags for the dashboards

### DIFF
--- a/components/dashboards/form/steps/Step1.js
+++ b/components/dashboards/form/steps/Step1.js
@@ -7,6 +7,8 @@ import { connect } from 'react-redux';
 
 // Constants
 import { FORM_ELEMENTS, TEMPLATES } from 'components/dashboards/form/constants';
+import TOPICS from 'static/data/TopicsTreeLite.json';
+import GEOGRAPHIES from 'static/data/GeographiesTreeLite.json';
 
 // Components
 import Field from 'components/form/Field';
@@ -14,7 +16,10 @@ import Input from 'components/form/Input';
 import Select from 'components/form/SelectInput';
 import TextArea from 'components/form/TextArea';
 import Checkbox from 'components/form/Checkbox';
-import Token from 'components/form/Token';
+import TreeSelector from 'components/form/tree-selector';
+
+// Helpers
+import { setInitialTreeState } from 'components/form/tree-selector/tree-selector-helper';
 
 // Wysiwyg
 import Wysiwyg from 'components/form/VizzWysiwyg';
@@ -141,20 +146,37 @@ class Step1 extends React.Component {
           >
             {Checkbox}
           </Field>
-          {/* TAGS */}
+          {/* TOPICS */}
           <Field
             ref={(c) => { if (c) FORM_ELEMENTS.elements.tags = c; }}
             onChange={value => this.props.onChange({ tags: value })}
+            data={this.props.topics}
             className="-fluid"
             properties={{
               name: 'tags',
-              label: 'Tags',
+              label: 'Topics',
               required: false,
               default: this.state.form.tags,
               value: this.state.form.tags
             }}
           >
-            {Token}
+            {TreeSelector}
+          </Field>
+          {/* GEOGRAPHIES */}
+          <Field
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.tags = c; }}
+            onChange={value => this.props.onChange({ locations: value })}
+            data={this.props.geographies}
+            className="-fluid"
+            properties={{
+              name: 'locations',
+              label: 'Geographies',
+              required: false,
+              default: this.state.form.locations,
+              value: this.state.form.locations
+            }}
+          >
+            {TreeSelector}
           </Field>
         </fieldset>
 
@@ -242,11 +264,15 @@ Step1.propTypes = {
   form: PropTypes.object,
   basic: PropTypes.bool,
   user: PropTypes.object,
+  topics: PropTypes.array,
+  geographies: PropTypes.array,
   onChange: PropTypes.func
 };
 
-export default connect(
-  state => ({
-    user: state.user
-  })
-)(Step1);
+const mapStateToProps = (state, ownProps) => ({
+  user: state.user,
+  topics: setInitialTreeState(TOPICS, (ownProps.form && ownProps.form.tags) || []),
+  geographies: setInitialTreeState(GEOGRAPHIES, (ownProps.form &&ownProps.form.locations) || [])
+});
+
+export default connect(mapStateToProps)(Step1);

--- a/components/form/tree-selector/index.js
+++ b/components/form/tree-selector/index.js
@@ -1,0 +1,3 @@
+import TreeSelectorComponent from './tree-selector-component';
+
+export default TreeSelectorComponent;

--- a/components/form/tree-selector/tree-selector-component.js
+++ b/components/form/tree-selector/tree-selector-component.js
@@ -1,0 +1,56 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import DropdownTreeSelect from 'react-dropdown-tree-select';
+
+import FormElement from './../FormElement';
+
+class TreeSelector extends FormElement {
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  triggerChange(selected) {
+    this.setState({ selected, value: selected.map(s => s.value) }, () => {
+      // Trigger validation
+      this.triggerValidate();
+      // Publish the new value to the form
+      if (this.props.onChange) this.props.onChange(this.state.value);
+    });
+  }
+
+  render() {
+    const { showDropdown, placeholderText, data, onChange, classNames } = this.props;
+    const datasetFilterClass = classnames({
+      'c-tree-selector': true,
+      classNames: !!classNames
+    });
+
+    return (
+      <div className={datasetFilterClass}>
+        <DropdownTreeSelect
+          showDropdown={showDropdown}
+          placeholderText={placeholderText}
+          data={data}
+          onChange={(_, selectedNodes) => this.triggerChange(selectedNodes)}
+        />
+      </div>
+    );
+  }
+}
+
+TreeSelector.propTypes = {
+  data: PropTypes.array.isRequired,
+  classNames: PropTypes.string,
+  onChange: PropTypes.func,
+  placeholderText: PropTypes.string,
+  showDropdown: PropTypes.bool
+};
+
+TreeSelector.defaultProps = {
+  data: [],
+  showDropdown: true,
+  onChange: () => {}
+};
+
+export default TreeSelector;

--- a/components/form/tree-selector/tree-selector-helper.js
+++ b/components/form/tree-selector/tree-selector-helper.js
@@ -1,0 +1,32 @@
+/**
+ * @typedef Node
+ * @property {string} label
+ * @property {string} value
+ * @property {boolean} checked
+ * @property {Node[]} children
+ */
+
+/**
+ * @typedef {Node[]} Tree
+ */
+
+/**
+ * Return a new tree whose selected elements are checked and
+ * the other ones unchecked
+ * @param {Tree} tree Initial tree
+ * @param {string[]} selectedItems Values of the items to check
+ */
+export const setInitialTreeState = (tree = [], selectedItems = []) => {
+  /** @type {Tree} */
+  const newTree = [];
+
+  for (let i = 0, j = tree.length; i < j; i++) {
+    const node = tree[i];
+    newTree.push(Object.assign({}, node, {
+      checked: selectedItems.indexOf(node.value) !== -1,
+      children: setInitialTreeState(node.children || [], selectedItems)
+    }));
+  }
+
+  return newTree;
+};

--- a/css/components/ui/tree_selector.scss
+++ b/css/components/ui/tree_selector.scss
@@ -7,11 +7,12 @@
     border-top: rgba($black, .05) 1px solid;
     background: $white;
     box-shadow: 0 5px 8px rgba($black, .15);
+    z-index: 10000; // FIXME: Above the wysiwyg
 
     .node {
       display: flex;
       align-items: center;
-      padding: 5px 10px;
+      padding: 10px;
 
       &.hide {
         display: none;
@@ -19,6 +20,7 @@
 
       > label {
         position: relative;
+        margin: 0;
         padding: 0 0 0 10px;
       }
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-dnd": "2.4.0",
     "react-dnd-html5-backend": "2.4.1",
     "react-dom": "15.6.2",
-    "react-dropdown-tree-select": "0.0.1-beta.11",
+    "react-dropdown-tree-select": "1.0.4",
     "react-dropzone": "3.13.3",
     "react-ga": "^2.4.1",
     "react-graph-vis": "0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8035,15 +8035,14 @@ react-dom@15.6.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-dropdown-tree-select@0.0.1-beta.11:
-  version "0.0.1-beta.11"
-  resolved "https://registry.yarnpkg.com/react-dropdown-tree-select/-/react-dropdown-tree-select-0.0.1-beta.11.tgz#bbcc463fc946fba4c508d177d19b08a338dabfa1"
+react-dropdown-tree-select@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-dropdown-tree-select/-/react-dropdown-tree-select-1.0.4.tgz#5b27ecd5e35d027fb81f850d84c7f15e2ddaf241"
   dependencies:
     classnames "^2.2.5"
     lodash "^4.17.4"
     prop-types "^15.5.8"
-    react "^15.5.4"
-    react-simple-dropdown "^2.0.0"
+    react-simple-dropdown "^3.2.0"
 
 react-dropzone@3.13.3:
   version "3.13.3"
@@ -8254,11 +8253,12 @@ react-select@^1.0.0-rc.10:
     prop-types "^15.5.8"
     react-input-autosize "^2.1.2"
 
-react-simple-dropdown@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-simple-dropdown/-/react-simple-dropdown-2.0.0.tgz#685215e77d69133fe490b06b5cb4c16a7eae3968"
+react-simple-dropdown@^3.2.0:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/react-simple-dropdown/-/react-simple-dropdown-3.2.3.tgz#c9737bcb7a54c7de267a1afeeec04de588a3fa7b"
   dependencies:
     classnames "^2.1.2"
+    prop-types "^15.5.8"
 
 react-slick@^0.14.11:
   version "0.14.11"
@@ -8360,7 +8360,7 @@ react@15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react@15.6.2, react@^15.4.1, react@^15.5.4:
+react@15.6.2, react@^15.4.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:


### PR DESCRIPTION
This PR lets the user choose topics and geographies for the dashboards when creating or editing them.

To test this PR, go the the dashboard creation page, choose a few topics and geographies and save it. Then you can edit it and update its values.

**NOTE:** I could not test properly the edition phase because the API wouldn't let me create a dashboard.

[Pivotal task (first part)](https://www.pivotaltracker.com/story/show/159102568)