### PR TITLE
Bug: user unable to add widgets in the dashboards

### DIFF
--- a/components/app/explore/DatasetWidgetChart.js
+++ b/components/app/explore/DatasetWidgetChart.js
@@ -1,14 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { VegaChart } from 'widget-editor'
+import { VegaChart, getVegaTheme } from 'widget-editor'
 
 // Components
 import Spinner from 'components/ui/Spinner';
-
-// Helpers
-// import ChartTheme from 'utils/widgets/theme';
-import { getVegaTheme } from 'widget-editor';
 
 class DatasetWidgetChart extends React.Component {
   constructor(props) {
@@ -16,6 +12,7 @@ class DatasetWidgetChart extends React.Component {
 
     this.state = {
       widget: props.widget,
+      theme: getVegaTheme(props.mode === 'thumbnail'),
       loading: false
     };
 
@@ -25,7 +22,8 @@ class DatasetWidgetChart extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      widget: nextProps.widget
+      widget: nextProps.widget,
+      theme: getVegaTheme(nextProps.mode === 'thumbnail'),
     });
   }
 
@@ -46,9 +44,8 @@ class DatasetWidgetChart extends React.Component {
   }
 
   render() {
-    const { widgetConfig } = this.state.widget;
+    const { widgetConfig, theme } = this.state.widget;
     const { mode } = this.props;
-    const themeObj = getVegaTheme(mode === 'thumbnail');
     const classname = classnames({
       'c-widget-chart': true,
       '-thumbnail': (mode === 'thumbnail')
@@ -62,7 +59,7 @@ class DatasetWidgetChart extends React.Component {
         />
         <VegaChart
           data={widgetConfig}
-          theme={themeObj}
+          theme={theme}
           showLegend={mode !== 'thumbnail'}
           reloadOnResize
           toggleLoading={this.triggerToggleLoading}

--- a/components/dashboards/wysiwyg/widget-block-edition/widget-block-edition-component.js
+++ b/components/dashboards/wysiwyg/widget-block-edition/widget-block-edition-component.js
@@ -59,8 +59,6 @@ export default function WidgetBlockEdition({ data, onChangeTab, onSelectWidget, 
                   showFavourite={false}
                 />
 
-                <Spinner isLoading={data.loading} className="-relative -small -light" />
-
                 <Paginator
                   options={{
                     size: data.total,


### PR DESCRIPTION
This PR fixes a bug where the user would be unable to add widgets to the dashboards due to an infinite render loop.

In `DatasetWidgetChart`, when `VegaChart` renders, it executes its prop `toggleLoading` to let the parent know about its loading state. When this occurs, `DatasetWidgetChart` renders again. This wouldn't be an issue if the theme wouldn't be generated in the `render` function. Indeed, `VegaChart` monitors the change of its prop `theme` and when updated, it re-renders again, executing, once again, `toggleLoading` and so on. Here's the infinite loop.

To address this, this PR just caches the theme within the state of `DatasetWidgetChart`.

## Testing instructions

1. Go to this page: http://localhost:3000/admin/dashboards/dashboards/new
2. Click the widget button of the toolbar

At this point, you should see the list of widgets.

## Pivotal

[Pivotal task](https://www.pivotaltracker.com/story/show/159172163)