### PR TITLE
Bug: unable to see specific dashboard

### DIFF
--- a/components/dashboards/detail/dashboard-detail-actions.js
+++ b/components/dashboards/detail/dashboard-detail-actions.js
@@ -11,7 +11,7 @@ export const fetchDashboard = createThunkAction('DASHBOARD_PREVIEW_FETCH_DATA', 
   dispatch(setLoading(true));
   dispatch(setError(null));
 
-  return fetch(new Request(`${process.env.API_URL}/dashboards/${payload.id}`))
+  return fetch(new Request(`${process.env.API_URL}/dashboards/${payload.id}?env=${API_ENV}`))
     .then((response) => {
       if (response.ok) return response.json();
       throw new Error(response.statusText);


### PR DESCRIPTION
This PR fixes a bug where the user wouldn't be able to see a specific dashboard created in My Prep.

## Testing instructions

1. Go to http://localhost:3000/dashboards/test-clement-3b129601-8862-4901-9cf3-9d8807cf9607

You should see a dashboard (with a broken widget, no worries about that).

## Pivotal

Not tracked.