### PR TITLE
Bug: map widgets without expanded legend in PDF

### DIFF
--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -210,7 +210,8 @@ class EmbedMap extends Page {
               setLayerGroupsOrder={() => {}}
               setLayerGroupActiveLayer={() => {}}
               interactionDisabled
-              expanded={false}
+              expanded // We want the legend expanded by default
+                       // for when the embed is used to generate a PDF
             />
 
             { modalOpened && this.getModal() }


### PR DESCRIPTION
This PR fixes an issue where the map widgets are exported as PDFs with their legend contracted.

## Testing instructions
Since the export feature is based on the embed version of the widgets, the test is for the embed page.

1. Go to http://localhost:3000/embed/map/57117074-8b58-4030-888f-8d4e11103af6

The legend of the widget should be expanded.

## Pivotal
[Task (see comments)](https://www.pivotaltracker.com/story/show/155199374)