### PR TITLE
Bugs: My Prep issues

### DIFF
--- a/components/app/myprep/widgets/pages/edit.js
+++ b/components/app/myprep/widgets/pages/edit.js
@@ -44,6 +44,30 @@ const FORM_ELEMENTS = {
 };
 
 class WidgetsEdit extends React.Component {
+  /**
+   * Return whether the widget is an embed
+   * @static
+   * @param {any} widget Widget attributes object
+   * @returns {boolean}
+   */
+  static isEmbedWidget(widget) {
+    return !!(widget
+      // Some widgets have not been created with the widget editor
+      // so the paramsConfig attribute doesn't exist
+      && (
+        (
+          widget.widgetConfig.paramsConfig
+          && widget.widgetConfig.paramsConfig.visualizationType === 'embed'
+        )
+        || (
+          // Case of a widget created outside of the widget editor
+          widget.widgetConfig.type
+          && widget.widgetConfig.type === 'embed'
+        )
+      )
+    );
+  }
+
   constructor(props) {
     super(props);
 
@@ -197,104 +221,113 @@ class WidgetsEdit extends React.Component {
           className="-light"
           isLoading={loading}
         />
-        {widget &&
-        <div>
-          <WidgetEditor
-            datasetId={datasetId}
-            widgetId={widget.id}
-            saveButtonMode="never"
-            embedButtonMode="never"
-            titleMode="never"
-            provideWidgetConfig={(func) => { this.onGetWidgetConfig = func; }}
-          />
-          <div className="form-container">
-            <form ref={(node) => { this.form = node; }} className="form-container" onSubmit={this.onSubmit}>
-              <fieldset className="c-field-container">
-                <Field
-                  ref={(c) => { if (c) FORM_ELEMENTS.elements.title = c; }}
-                  onChange={value => this.handleChange({ name: value })}
-                  validations={['required']}
-                  properties={{
-                    title: 'title',
-                    label: 'Title',
-                    type: 'text',
-                    required: true,
-                    default: widgetAtts.name,
-                    placeholder: 'Widget title'
-                  }}
-                >
-                  {Input}
-                </Field>
-                <Field
-                  ref={(c) => { if (c) FORM_ELEMENTS.elements.description = c; }}
-                  onChange={value => this.handleChange({ description: value })}
-                  properties={{
-                    title: 'description',
-                    label: 'Description',
-                    type: 'text',
-                    default: widgetAtts.description,
-                    placeholder: 'Widget description'
-                  }}
-                >
-                  {Input}
-                </Field>
-                <Field
-                  ref={(c) => { if (c) FORM_ELEMENTS.elements.authors = c; }}
-                  onChange={value => this.handleChange({ authors: value })}
-                  properties={{
-                    title: 'authors',
-                    label: 'Authors',
-                    type: 'text',
-                    default: widgetAtts.authors,
-                    placeholder: 'Author name'
-                  }}
-                >
-                  {Input}
-                </Field>
-                <div className="source-container">
+        {widget && (
+          <div>
+            { !WidgetsEdit.isEmbedWidget(widgetAtts) && (
+              <WidgetEditor
+                datasetId={datasetId}
+                widgetId={widget.id}
+                saveButtonMode="never"
+                embedButtonMode="never"
+                titleMode="never"
+                provideWidgetConfig={(func) => { this.onGetWidgetConfig = func; }}
+              />
+            )}
+            { WidgetsEdit.isEmbedWidget(widgetAtts) && (
+              <iframe
+                title={widgetAtts.name}
+                src={widgetAtts.widgetConfig.url}
+                frameBorder="0"
+              />
+            )}
+            <div className="form-container">
+              <form ref={(node) => { this.form = node; }} className="form-container" onSubmit={this.onSubmit}>
+                <fieldset className="c-field-container">
                   <Field
-                    ref={(c) => { if (c) FORM_ELEMENTS.elements.source = c; }}
-                    onChange={value => this.handleChange({ source: value })}
+                    ref={(c) => { if (c) FORM_ELEMENTS.elements.title = c; }}
+                    onChange={value => this.handleChange({ name: value })}
+                    validations={['required']}
                     properties={{
-                      title: 'source',
-                      label: 'Source name',
+                      title: 'title',
+                      label: 'Title',
                       type: 'text',
-                      default: widgetAtts.source,
-                      placeholder: 'Source name'
+                      required: true,
+                      default: widgetAtts.name,
+                      placeholder: 'Widget title'
                     }}
                   >
                     {Input}
                   </Field>
                   <Field
-                    ref={(c) => { if (c) FORM_ELEMENTS.elements.sourceUrl = c; }}
-                    onChange={value => this.handleChange({ sourceUrl: value })}
+                    ref={(c) => { if (c) FORM_ELEMENTS.elements.description = c; }}
+                    onChange={value => this.handleChange({ description: value })}
                     properties={{
-                      title: 'sourceUrl',
-                      label: 'Source URL',
+                      title: 'description',
+                      label: 'Description',
                       type: 'text',
-                      default: widgetAtts.sourceUrl,
-                      placeholder: 'Paste a URL here'
+                      default: widgetAtts.description,
+                      placeholder: 'Widget description'
                     }}
                   >
                     {Input}
                   </Field>
+                  <Field
+                    ref={(c) => { if (c) FORM_ELEMENTS.elements.authors = c; }}
+                    onChange={value => this.handleChange({ authors: value })}
+                    properties={{
+                      title: 'authors',
+                      label: 'Authors',
+                      type: 'text',
+                      default: widgetAtts.authors,
+                      placeholder: 'Author name'
+                    }}
+                  >
+                    {Input}
+                  </Field>
+                  <div className="source-container">
+                    <Field
+                      ref={(c) => { if (c) FORM_ELEMENTS.elements.source = c; }}
+                      onChange={value => this.handleChange({ source: value })}
+                      properties={{
+                        title: 'source',
+                        label: 'Source name',
+                        type: 'text',
+                        default: widgetAtts.source,
+                        placeholder: 'Source name'
+                      }}
+                    >
+                      {Input}
+                    </Field>
+                    <Field
+                      ref={(c) => { if (c) FORM_ELEMENTS.elements.sourceUrl = c; }}
+                      onChange={value => this.handleChange({ sourceUrl: value })}
+                      properties={{
+                        title: 'sourceUrl',
+                        label: 'Source URL',
+                        type: 'text',
+                        default: widgetAtts.sourceUrl,
+                        placeholder: 'Paste a URL here'
+                      }}
+                    >
+                      {Input}
+                    </Field>
+                  </div>
+                </fieldset>
+                <div className="buttons-container">
+                  <Button
+                    properties={{
+                      type: 'submit',
+                      disabled: submitting,
+                      className: '-a'
+                    }}
+                  >
+                    Save
+                  </Button>
                 </div>
-              </fieldset>
-              <div className="buttons-container">
-                <Button
-                  properties={{
-                    type: 'submit',
-                    disabled: submitting,
-                    className: '-a'
-                  }}
-                >
-                  Save
-                </Button>
-              </div>
-            </form>
+              </form>
+            </div>
           </div>
-        </div>
-        }
+        )}
       </div>
     );
   }

--- a/components/app/myprep/widgets/pages/edit.js
+++ b/components/app/myprep/widgets/pages/edit.js
@@ -67,7 +67,7 @@ class WidgetsEdit extends React.Component {
     });
 
     this.widgetService = new WidgetService(this.props.id,
-      { apiURL: process.env.CONTROL_TOWER_URL });
+      { apiURL: process.env.WRI_API_URL });
 
     // ------------------- Bindings -----------------------
     this.onSubmit = this.onSubmit.bind(this);

--- a/components/widgets/list/WidgetActionsTooltip.js
+++ b/components/widgets/list/WidgetActionsTooltip.js
@@ -44,23 +44,23 @@ class WidgetActionsTooltip extends React.Component {
         <ul>
           { this.props.isWidgetOwner &&
             <li>
-              <button onClick={() => this.handleClick('edit_widget')}>
+              <button type="button" onClick={() => this.handleClick('edit_widget')}>
                 Edit widget
               </button>
             </li>
           }
           <li>
-            <button onClick={() => this.handleClick('share_embed')}>
+            <button type="button" onClick={() => this.handleClick('share_embed')}>
               Share/Embed
             </button>
           </li>
           <li>
-            <button onClick={() => this.handleClick('go_to_dataset')}>
+            <button type="button" onClick={() => this.handleClick('go_to_dataset')}>
               Go to dataset
             </button>
           </li>
           <li>
-            <button onClick={() => this.handleClick('download_pdf')}>
+            <button type="button" onClick={() => this.handleClick('download_pdf')}>
               Download as PDF
             </button>
           </li>

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -356,7 +356,7 @@ class WidgetCard extends PureComponent {
   }
 
   handleGoToDataset() {
-    Router.pushRoute('explore_detail', { id: this.props.widget.dataset });
+    window.location.href = `/dataset/${this.props.widget.dataset}`;
   }
 
   handleDownloadPDF() {

--- a/css/components/app/myprep/widgets-edit.scss
+++ b/css/components/app/myprep/widgets-edit.scss
@@ -1,0 +1,7 @@
+.c-myprep-widgets-edit {
+  iframe {
+    display: block;
+    width: 100%;
+    min-height: 400px;
+  }
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -217,6 +217,7 @@
 
 // MYPREP
 @import "./components/app/myprep/profiles-tab";
+@import "./components/app/myprep/widgets-edit";
 
 // DASHBOARDS
 @import './components/app/dashboards/dashboard_card';


### PR DESCRIPTION
This PR fixes several issues located in My Prep: 
1. The user wouldn't be able to edit existing widgets
2. The user would be shown a misleading UI when editing a widget of type "embed"
3. The user wouldn't be able to see the dataset of a widget

## Testing instructions

### 1. User can edit widgets
1. Make sure you use the staging ENV variables.
2. Go to http://localhost:3000/myprep/widgets/my_widgets
3. Click the "Widget actions" button of one of the widgets and click "Edit widget"

The page should load correctly.

### 2. Editing a widget of type "embed" doesn't show the widget-editor
1. Create a widget of type "embed" if you haven't got one
2. Go to http://localhost:3000/myprep/widgets/my_widgets
3. Click the "Widget actions" button of the widget and click "Edit widget"

The page shouldn't show a widget-editor instance, but instead, a preview of the widget in a iframe.

### 3. User can see the dataset of a widget
2. Go to http://localhost:3000/myprep/widgets/my_widgets
3. Click the "Widget actions" button of one of the widgets and click "Go to dataset"

The user should be correctly brought to the dataset.

## Pivotal
Some of the issues are tracked by [this task](https://www.pivotaltracker.com/story/show/159172219).