### PR TITLE
Bug: widgets downloaded as PDFs incorrectly displayed

### DIFF
--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -370,7 +370,7 @@ class WidgetCard extends PureComponent {
 
     const link = document.createElement('a');
     link.setAttribute('download', '');
-    link.href = `${process.env.CONTROL_TOWER_URL}/v1/webshot/pdf?filename=${filename}&width=790&height=580&waitFor=8000&url=${origin}/${path}/${type}/${id}`;
+    link.href = `${process.env.CONTROL_TOWER_URL}/v1/webshot/pdf?filename=${filename}&width=790&height=580&backgrounds=true&waitFor=8000&url=${origin}/${path}/${type}/${id}`;
 
     // link.click() doesn't work on Firefox for some reasons
     // so we have to create an event manually


### PR DESCRIPTION
This PR makes sure that when we use the [webshot service](https://github.com/resource-watch/webshot) to download a widget as a PDF, the backgrounds are not stripped.

Here's an image showing the difference with (left) and without (right) this PR:
<p align="center">
<img width="1279" alt="On the right, a PDF of a pie chart whose legend doesn't show the colours. On the left, a PDF of the same pie chart where the legend displays the colours." src="https://user-images.githubusercontent.com/6073968/44198789-30944a80-a13a-11e8-89b9-ff6c4336bd99.png">
</p>

## Testing instructions
1. Create a pie chart
2. Go to My Prep: https://staging.prepdata.org/myprep/widgets/my_widgets
3. Click the "Widget actions" button of the widget, and then "Download as PDF"

You should download a PDF with the legend correctly displayed.

**⚠️ NOTE:** while [this PR](https://github.com/resource-watch/webshot/pull/2) is not merged, the service won't generate the backgrounds correctly.

## Pivotal
Part of [this task](https://www.pivotaltracker.com/story/show/159172219).