### PR TITLE
Bug: missing icons in the embeds

### DIFF
--- a/components/app/layout/EmbedLayout.js
+++ b/components/app/layout/EmbedLayout.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Icons as WEIcons } from 'widget-editor';
 
 // Redux
 import { connect } from 'react-redux';
@@ -48,6 +49,7 @@ class EmbedLayout extends React.Component {
         />
 
         <Icons />
+        <WEIcons />
 
         {this.props.children}
 

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -164,37 +164,37 @@ class EmbedWidget extends Page {
         title="Partnership for Resilience and Preparedness"
         description=""
         >
-        <div className="c-embed-widget">
-        <div className="widget-title">
-        <h4>–</h4>
-        </div>
+          <div className="c-embed-widget">
+            <div className="widget-title">
+              <h4>–</h4>
+            </div>
 
-        <div className="widget-content">
-        <p>{'Sorry, the widget couldn\'t be loaded'}</p>
-        </div>
+            <div className="widget-content">
+              <p>{'Sorry, the widget couldn\'t be loaded'}</p>
+            </div>
 
-        { this.isLoadedExternally() && (
-          <div className="widget-footer">
-          <a href="/" target="_blank" rel="noopener noreferrer">
-          <img
-          className="prep-logo"
-          src={'/static/images/logo-blue@2x.png'}
-          alt="Partnership for Resilience and Preparedness"
-          />
-          </a>
-          <div>
-          Powered by
-          <a href="http://www.resourcewatch.org/" target="_blank" rel="noopener noreferrer">
-          <img
-          className="embed-logo"
-          src={'/static/images/logo-embed.png'}
-          alt="Resource Watch"
-          />
-          </a>
+            { this.isLoadedExternally() && (
+              <div className="widget-footer">
+                <a href="/" target="_blank" rel="noopener noreferrer">
+                  <img
+                    className="prep-logo"
+                    src={'/static/images/logo-blue@2x.png'}
+                    alt="Partnership for Resilience and Preparedness"
+                  />
+                </a>
+                <div>
+                  Powered by
+                  <a href="http://www.resourcewatch.org/" target="_blank" rel="noopener noreferrer">
+                    <img
+                      className="embed-logo"
+                      src={'/static/images/logo-embed.png'}
+                      alt="Resource Watch"
+                    />
+                    </a>
+                </div>
+              </div>
+            ) }
           </div>
-          </div>
-        ) }
-        </div>
         </EmbedLayout>
       );
     }


### PR DESCRIPTION
This PR fixes an issue where some icons could be missing from the embeds of Vega charts.

## Testing instructions
1. Open http://localhost:3000/embed/widget/2d35e915-2cd7-4892-8288-aae9dfb982ec

You should see a close button in the legend.

## Pivotal
Not tracked.