### PR TITLE
Add authoring attributes do the dashboards

### DIFF
--- a/components/dashboards/form/DashboardsForm.js
+++ b/components/dashboards/form/DashboardsForm.js
@@ -92,6 +92,25 @@ class DashboardsForm extends React.Component {
             delete body.data.id;
           }
 
+          // We make sure to send the ID of the author in the request
+          // otherwise it fails
+          if (body.data.attributes.author_attributes) {
+            body.data.attributes.author_attributes.id = this.state.form.author.id;
+          }
+
+          // The author attributes are sent as "author_attributes" but
+          // returned by the API as "author" so we just remove them before
+          // sending the form
+          if (body.data.attributes.author) {
+            delete body.data.attributes.author;
+          }
+
+          // If the user wants to remove the logo of a dashboard, we need to
+          // make sure to send null and not an empty string
+          if (body.data.attributes.author_attributes && body.data.attributes.author_attributes.logo === '') {
+            body.data.attributes.author_attributes.logo = null;
+          }
+
           // Save data
           this.service.saveData({
             id: id || '',

--- a/components/dashboards/form/steps/Step1.js
+++ b/components/dashboards/form/steps/Step1.js
@@ -229,7 +229,9 @@ class Step1 extends React.Component {
               name: 'authorImg',
               label: 'Author\'s logo',
               placeholder: 'Browse file',
-              default: this.state.form.author && this.state.form.author.logo
+              default: (this.state.form.author && this.state.form.author.logo && this.state.form.author.logo !== '/logos/original/missing.png')
+                ? this.state.form.author.logo
+                : null
             }}
           >
             {FileImage}

--- a/components/dashboards/form/steps/Step1.js
+++ b/components/dashboards/form/steps/Step1.js
@@ -16,6 +16,7 @@ import Input from 'components/form/Input';
 import Select from 'components/form/SelectInput';
 import TextArea from 'components/form/TextArea';
 import Checkbox from 'components/form/Checkbox';
+import FileImage from 'components/form/FileImage';
 import TreeSelector from 'components/form/tree-selector';
 
 // Helpers
@@ -177,6 +178,61 @@ class Step1 extends React.Component {
             }}
           >
             {TreeSelector}
+          </Field>
+
+          {/* AUTHOR */}
+          <Field
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.author = c; }}
+            onChange={value => this.props.onChange({
+              author_attributes: Object.assign({}, this.props.form.author_attributes, { name: value })
+            })}
+            validations={['required']}
+            className="-fluid"
+            properties={{
+              name: 'author',
+              label: 'Author',
+              type: 'text',
+              required: true,
+              default: this.state.form.author && this.state.form.author.name
+            }}
+          >
+            {Input}
+          </Field>
+
+          {/* AUTHOR */}
+          <Field
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.authorUrl = c; }}
+            onChange={value => this.props.onChange({
+              author_attributes: Object.assign({}, this.props.form.author_attributes, { url: value })
+            })}
+            validations={['url']}
+            className="-fluid"
+            properties={{
+              name: 'authorUrl',
+              label: 'Author\'s website',
+              type: 'text',
+              required: false,
+              default: this.state.form.author && this.state.form.author.url
+            }}
+          >
+            {Input}
+          </Field>
+
+          {/* IMAGE */}
+          <Field
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.authorImg = c; }}
+            onChange={value => this.props.onChange({
+              author_attributes: Object.assign({}, this.props.form.author_attributes, { logo: value })
+            })}
+            className="-fluid"
+            properties={{
+              name: 'authorImg',
+              label: 'Author\'s logo',
+              placeholder: 'Browse file',
+              default: this.state.form.author && this.state.form.author.logo
+            }}
+          >
+            {FileImage}
           </Field>
         </fieldset>
 

--- a/pages/app/DashboardsDetail.js
+++ b/pages/app/DashboardsDetail.js
@@ -134,6 +134,20 @@ class DashboardsDetail extends Page {
                   </div>
                 </div>
               }
+
+              {dashboardDetail.dashboard.author && dashboardDetail.dashboard.author.name && (
+                <div className="row">
+                  <div className="column small-12">
+                    <div className="page-header-partner">
+                      <img
+                        src={dashboardDetail.dashboard.author.logo}
+                        alt={dashboardDetail.dashboard.author.name}
+                      />
+                      <p>{dashboardDetail.dashboard.author.name}</p>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 

--- a/services/DashboardsService.js
+++ b/services/DashboardsService.js
@@ -62,7 +62,7 @@ export default class DashboardsService {
   saveData({ type, body, id }) {
     return new Promise((resolve, reject) => {
       post({
-        url: `${process.env.API_URL}/dashboards/${id}`,
+        url: `${process.env.API_URL}/dashboards/${id}?env=${process.env.API_ENV}`,
         type,
         body,
         headers: [{


### PR DESCRIPTION
This PR lets the user add information about the author of the dashboards: name, URL and logo.

## Testing instructions
1. Go to http://localhost:3000/admin/dashboards/dashboards
2. Click the "New dashboard" button
3. Fill in the fields and save
4. Search for the dashboard, edit the authoring fields and/or remove the logo

All of these actions should be successful.

## Pivotal
Part of [this task](https://www.pivotaltracker.com/story/show/158256199).